### PR TITLE
test: configure S3Client for local testing in migration_runner tests

### DIFF
--- a/src/migration/migration_runner.test.ts
+++ b/src/migration/migration_runner.test.ts
@@ -40,6 +40,10 @@ describe("MigrationRunner", () => {
   let migrationRunner: MigrationRunner;
 
   beforeAll(() => {
+    s3Client = new S3Client({
+      endpoint: `http://s3.localhost.localstack.cloud:4566`,
+      region: "ap-northeast-1",
+    });
     dynamoDBClient = new DynamoDBClient({
       endpoint: "http://localhost:4566",
       region: "ap-northeast-1",


### PR DESCRIPTION
fix to `error TS2454: Variable 's3Client' is used before being assigned.`