### PR TITLE
Fix: Add missing "types" field in package.json for proper TypeScript support

### DIFF
--- a/.changeset/dull-kangaroos-grow.md
+++ b/.changeset/dull-kangaroos-grow.md
@@ -1,0 +1,5 @@
+---
+"@purpom-media-lab/amplify-data-migration": patch
+---
+
+Added missing `"types"` field to `package.json` to resolve TypeScript import errors. Also fixed a typo in import paths used in generated migration files.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@purpom-media-lab/amplify-data-migration",
   "version": "1.2.0",
   "description": "Amplify Data Migration Tool",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/purpom-media-lab/amplify-data-migration.git"

--- a/src/create/__snapshots__/create_migration_file_content.test.ts.snap
+++ b/src/create/__snapshots__/create_migration_file_content.test.ts.snap
@@ -7,7 +7,7 @@ exports[`createMigrationFileContent > should return Migration file content 1`] =
   Migration,
   MigrationContext,
   ModelTransformer,
-} from "@purpom-media-lab/ampify-data-migration";
+} from "@purpom-media-lab/amplify-data-migration";
 
 export default class TestMigration_1726384783922 implements Migration {
   readonly name = "test_migration";

--- a/src/create/create_migration_file_content.ts
+++ b/src/create/create_migration_file_content.ts
@@ -9,7 +9,7 @@ export const createMigrationClassContent = (
   Migration,
   MigrationContext,
   ModelTransformer,
-} from "@purpom-media-lab/ampify-data-migration";
+} from "@purpom-media-lab/amplify-data-migration";
 
 export default class ${className}_${timestamp} implements Migration {
   readonly name = "${migrationName}";


### PR DESCRIPTION
### 📝 Pull Request description

<img width="845" alt="image" src="https://github.com/user-attachments/assets/7198c678-a672-475c-bd18-5e4025c5c11d" />


### Summary

This PR adds the missing `"types"` field in `package.json` to enable proper TypeScript support when importing the package.

Currently, when using `@purpom-media-lab/amplify-data-migration` in a TypeScript project, the following error may occur:

```

Cannot find module '@purpom-media-lab/amplify-data-migration' or its corresponding type declarations.ts(2307)

```

Even though the package provides `lib/index.d.ts`, it is not recognized by TypeScript unless explicitly referenced in `package.json`.

---

### Changes

- Added `"types": "lib/index.d.ts"` to the root `package.json`
- This enables editors (such as VSCode) and the TypeScript compiler to resolve the type declarations correctly
- and fix typo : [fix(typo): correct import path for amplify-data-migration in migration files](https://github.com/purpom-media-lab/amplify-data-migration/pull/117/commits/a20c57d609a93e5cb23cf6eabf7a705892097bb4)

---

### Impact

- Fixes the TypeScript import and IntelliSense issues
- Improves developer experience when creating migration files in TypeScript

---

### Note

If you plan to publish this package to npm in the future, this change ensures it works well in standard TypeScript projects without requiring additional configuration or workarounds.


### ✅ Verification

After adding the `"types"` field, the following has been verified:

* Installing `@purpom-media-lab/amplify-data-migration` via `npm` in a TypeScript project

* Running the following command to generate a migration file:

  ```bash
  npx data-migration create --name test_migration --migrationsDir migrations
  ```

* Importing types and modules from the package in the generated migration file (e.g. `Migration`, `MigrationContext`, etc.)

✅ **The TypeScript compiler no longer throws the following error:**

```
Cannot find module '@purpom-media-lab/amplify-data-migration' or its corresponding type declarations.ts(2307)
```

This confirms that the `"types"` field correctly resolves to the bundled type definitions at `lib/index.d.ts`.



