### PR TITLE
fix: correct configuration key from 'workspace' to 'projects' in vitest.config.ts

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    workspace: ["packages/*/vitest.config.ts"],
+    projects: ["packages/*/vitest.config.ts"],
     coverage: {
       exclude: [
         "coverage/**",


### PR DESCRIPTION
fix #152 